### PR TITLE
Correct offset between pcolor and contours

### DIFF
--- a/triangle.py
+++ b/triangle.py
@@ -57,7 +57,7 @@ def hist2d(x, y, *args, **kwargs):
     Y = np.linspace(extent[1][0], extent[1][1], bins + 1)
     H, X, Y = np.histogram2d(x.flatten(), y.flatten(), bins=(X, Y))
 
-    V = sp.erf(np.arange(1, 2.1, 0.5) / np.sqrt(2))
+    V = sp.erf(np.arange(0.5, 2.1, 0.5) / np.sqrt(2))
     Hflat = H.flatten()
     inds = np.argsort(Hflat)[::-1]
     Hflat = Hflat[inds]


### PR DESCRIPTION
Because `pl.pcolor` and `pl.contour` (and `pl.contourf`) treat the bins differently, there was an offset between the color image and the plotted contours that was most visible with a small number of bins.
