### PR TITLE
Add explicit kwargs for plot_contours and plot_datapoints

### DIFF
--- a/triangle.py
+++ b/triangle.py
@@ -79,7 +79,10 @@ def corner(xs, labels=None, extents=None, truths=None, truth_color="#4682b4",
         xs = xs.T
     assert xs.shape[0] <= xs.shape[1], "I don't believe that you want more " \
                                        "dimensions than samples!"
-
+    
+    # backwards-compatibility
+    plot_contours = kwargs.get("smooth", plot_contours)
+    
     K = len(xs)
     factor = 2.0           # size of one side of one panel
     lbdim = 0.5 * factor   # size of left/bottom margin


### PR DESCRIPTION
I wanted to make a plot where I don't show contours, and I had to _look at the code_ to figure out how to do that. Preposterous.

There's also an API change here: `smooth` has been renamed `plot_contours` to be more like `plot_datapoints`. But `smooth` will still work because, yea, backwards compatibility and all that.

I also committed heresy and reformatted  the main docstring to use the `numpy`-style docstring formatting. I think it's easier to read than having weird things like ':param' floating around...
