### PR TITLE
Allow overplotting on a pre-made figure

### DIFF
--- a/triangle.py
+++ b/triangle.py
@@ -72,7 +72,7 @@ def corner(xs, labels=None, extents=None, truths=None, truth_color="#4682b4",
         Draw the individual data points.
     
     fig : matplotlib.Figure (optional)
-        
+        Overplot onto the provided figure object.
     
     """
 


### PR DESCRIPTION
This is to address #8 by allowing an optional `fig` kwarg. The user can pass in a pre-made `matplotlib.Figure` object and have `triangle.py` overplot on the pre-defined axes. 

Example:

```
fig = triangle.corner(flatchain1, ...)
fig = triangle.corner(flatchain2, ..., fig=fig)
```
