### PR TITLE
Adds new function to format exponents in the label

### DIFF
--- a/triangle.py
+++ b/triangle.py
@@ -547,7 +547,10 @@ def format_exponents_in_label(fig):
 
         label = old_label.replace("[{}]".format(units), "")
         exponent_text = exponent_text.replace("\\times", "")
-        s = r"{} [{} {}]".format(label, exponent_text, units)
+        if units == "":
+            s = r"{} [{}]".format(label, exponent_text)
+        else:
+            s = r"{} [{} {}]".format(label, exponent_text, units)
         s = s.replace("-", "\\textrm{-}")
         return s
 


### PR DESCRIPTION
This adds a single new function to post-process a figure moving the axes
exponents to the axes labels

The problem occurs when the data causes the ScalarFormatter to use an exponent. For example here is the [`demo.py`](https://github.com/dfm/triangle.py/blob/master/demo.py)  with a modification to the data in the form of

    data[:, 0] *= 1e8
    data[:, 1] *= 1e-8

![demo_old](https://cloud.githubusercontent.com/assets/1926734/8829981/9c67139a-3091-11e5-85f1-18b315628812.png)

On the yaxis in particular the exponent gets lost in the subplot: this is really a `matplotlib` issue, nevertheless a nice solution is to put the exponent into the axes label. Passing the `figure` object returned from `corner` as:

    triangle.format_exponents_in_label(figure)

produces something like this:

![demo](https://cloud.githubusercontent.com/assets/1926734/8829980/9c62198a-3091-11e5-96bc-35ff02abbfce.png)

This *could* be done in the `corner` function itself, and I am happy to rewrite this PR, but I wanted to submit it in a simple form first to explain the motivation and implementation in a clean way.

Notes:
* This will look rather strange if the original figure is produced without 


    `pl.rcParams['axes.formatter.use_mathtext'] = True `

  or some equivalent. 
