### PR TITLE
Make corner module callable

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -65,7 +65,7 @@ def _run_corner(nm, pandas=False, N=10000, seed=1234, ndim=3, ret=False,
         data = pd.DataFrame.from_items(zip(map("d{0}".format, range(ndim)),
                                            data.T))
 
-    fig = corner.corner(data, **kwargs)
+    fig = corner(data, **kwargs)
     fig.savefig(os.path.join(FIGURE_PATH, "corner_{0}.png".format(nm)))
     if ret:
         return fig


### PR DESCRIPTION
I'm tired of doing

``` python
import corner
corner.corner(samples)
```

So many extra keystrokes!

This pull request makes the `corner` module callable, so you can just do

``` python
import corner
corner(samples)
```

The change is fully backward compatible; you can still do the old methods as well:

``` python
import corner
corner.corner(samples)
corner.hist2d(samples)

from corner import corner
corner(samples)
```

I can't believe you didn't add this sooner :stuck_out_tongue: 
