### PR TITLE
Ensure all calls to contour have sorted levels

### DIFF
--- a/corner.py
+++ b/corner.py
@@ -488,9 +488,9 @@ def hist2d(x, y, bins=20, range=None, weights=None, levels=None, smooth=None,
     # This "color map" is the list of colors for the contour levels if the
     # contours are filled.
     rgba_color = colorConverter.to_rgba(color)
-    contour_cmap = [rgba_color] + [list(rgba_color) for l in levels]
+    contour_cmap =  [list(rgba_color) for l in levels] + [rgba_color]
     for i, l in enumerate(levels):
-        contour_cmap[i+1][-1] *= float(len(levels) - i) / (len(levels)+1)
+        contour_cmap[i][-1] *= float(i) / (len(levels)+1)
 
     # We'll make the 2D histogram to directly estimate the density.
     try:

--- a/corner.py
+++ b/corner.py
@@ -518,6 +518,7 @@ def hist2d(x, y, bins=20, range=None, weights=None, levels=None, smooth=None,
             V[i] = Hflat[sm <= v0][-1]
         except:
             V[i] = Hflat[0]
+    V.sort()
 
     # Compute the bin centers.
     X1, Y1 = 0.5 * (X[1:] + X[:-1]), 0.5 * (Y[1:] + Y[:-1])
@@ -555,7 +556,7 @@ def hist2d(x, y, bins=20, range=None, weights=None, levels=None, smooth=None,
 
     # Plot the base fill to hide the densest data points.
     if (plot_contours or plot_density) and not no_fill_contours:
-        ax.contourf(X2, Y2, H2.T, [V[-1], H.max()],
+        ax.contourf(X2, Y2, H2.T, [V.min(), H.max()],
                     cmap=white_cmap, antialiased=False)
 
     if plot_contours and fill_contours:
@@ -564,7 +565,7 @@ def hist2d(x, y, bins=20, range=None, weights=None, levels=None, smooth=None,
         contourf_kwargs["colors"] = contourf_kwargs.get("colors", contour_cmap)
         contourf_kwargs["antialiased"] = contourf_kwargs.get("antialiased",
                                                              False)
-        ax.contourf(X2, Y2, H2.T, np.concatenate([[H.max()], V, [0]]),
+        ax.contourf(X2, Y2, H2.T, np.concatenate([[0], V, [H.max()]]),
                     **contourf_kwargs)
 
     # Plot the density map. This can't be plotted at the same time as the

--- a/corner.py
+++ b/corner.py
@@ -22,6 +22,7 @@ __contributors__ = [
     "Phil Marshall @drphilmarshall",
     "Pierre Gratier @pirg",
     "Stephan Hoyer @shoyer",
+    "Víctor Zabalza @zblz",
     "Will Vousden @willvousden",
     "Wolfgang Kerzendorf @wkerzendorf",
 ]


### PR DESCRIPTION
With these changes, all calls to `plt.contourf` have sorted levels (see https://github.com/matplotlib/matplotlib/issues/5477 and https://github.com/matplotlib/matplotlib/pull/5485). This allows to use corner in matplotlib > 1.5.0.

Fixes #65 and #68 