### PR TITLE
More contour level fixes

### DIFF
--- a/corner.py
+++ b/corner.py
@@ -520,6 +520,11 @@ def hist2d(x, y, bins=20, range=None, weights=None, levels=None, smooth=None,
         except:
             V[i] = Hflat[0]
     V.sort()
+    if np.amin(np.diff(V)) == 0.0:
+        # We have two or more equal levels, matploltib will complain
+        idxs = np.where(np.diff(V) == 0)
+        V[idxs] *= 1. - 1e-4 * (1. / (np.arange(V[idxs].size) + 1.))
+
 
     # Compute the bin centers.
     X1, Y1 = 0.5 * (X[1:] + X[:-1]), 0.5 * (Y[1:] + Y[:-1])
@@ -566,8 +571,8 @@ def hist2d(x, y, bins=20, range=None, weights=None, levels=None, smooth=None,
         contourf_kwargs["colors"] = contourf_kwargs.get("colors", contour_cmap)
         contourf_kwargs["antialiased"] = contourf_kwargs.get("antialiased",
                                                              False)
-        ax.contourf(X2, Y2, H2.T, np.concatenate([[0], V, [H.max()]]),
-                    **contourf_kwargs)
+        ax.contourf(X2, Y2, H2.T, np.concatenate([[0], V,
+            [H.max() * (1 + 1e-4)]]), **contourf_kwargs)
 
     # Plot the density map. This can't be plotted at the same time as the
     # contour fills.

--- a/tests.py
+++ b/tests.py
@@ -44,6 +44,9 @@ def test_hist2d():
     _run_hist2d("smooth2", bins=50, smooth=(1.0, 1.5))
     _run_hist2d("philsplot", plot_datapoints=False, fill_contours=True,
                 levels=[0.68, 0.95], color="g", bins=50, smooth=1.)
+    _run_hist2d("lowN", N=20)
+    _run_hist2d("lowNfilled", N=20, fill_contours=True)
+    _run_hist2d("lowNnofill", N=20, no_fill_contours=True)
 
 
 def _run_corner(nm, pandas=False, N=10000, seed=1234, ndim=3, ret=False,


### PR DESCRIPTION
So in #70 I missed a few cases that were not covered by the tests. When the number of counts is (very) low and there are contours around single counts, the contour levels will be duplicated. However, matplotlib now complains if the levels are not strictly increasing, so it throws the same error as in #68. 

I found this while doing travis testing on very small chains to test code paths rather than actual data. The analysis of these small chains is obviously absurd, but corner should still not fail.

I have added a few hacks that move the contour levels by up to a factor 1e-4 when they are duplicated. This is not strictly correct, but if the levels are duplicated the plot is probably bad enough that just care about it not failing. I also added three tests that will fail without this PR's changes.