### PR TITLE
fix title_kwargs typo in demo

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -18,7 +18,7 @@ figure = corner.corner(data, labels=[r"$x$", r"$y$", r"$\log \alpha$",
                                      r"$\Gamma \, [\mathrm{parsec}]$"],
                          truths=[0.0, 0.0, 0.0],
                          quantiles=[0.16, 0.5, 0.84],
-                         show_titles=True, title_args={"fontsize": 12})
+                         show_titles=True, title_kwargs={"fontsize": 12})
 figure.gca().annotate("A Title", xy=(0.5, 1.0), xycoords="figure fraction",
                       xytext=(0, -5), textcoords="offset points",
                       ha="center", va="top")


### PR DESCRIPTION
Passing `title_args` to `corner.corner` doesn't do anything.  I'm guessing `title_kwargs` was meant instead.