### PR TITLE
Number of bins as integer

### DIFF
--- a/corner.py
+++ b/corner.py
@@ -210,7 +210,7 @@ def corner(xs, bins=20, range=None, weights=None, color="k",
 
     # Parse the bin specifications.
     try:
-        bins = [float(bins) for _ in range]
+        bins = [int(bins) for _ in range]
     except TypeError:
         if len(bins) != len(range):
             raise ValueError("Dimension mismatch between bins and range")


### PR DESCRIPTION
This avoids a warning messages with numpy==1.11.0 by converting the number of bins from floating point numbers to integers.