### PR TITLE
Listing runtime dependencies in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,4 +37,5 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
     ],
+    install_requires=['numpy', 'matplotlib']
 )


### PR DESCRIPTION
Run into this while tried to build a conda package from the new release.

(Btw do you want me to add the conda install option to the docs?)