### PR TITLE
Option to plot priors on top of histograms

### DIFF
--- a/corner/corner.py
+++ b/corner/corner.py
@@ -22,7 +22,7 @@ def corner(xs, bins=20, range=None, weights=None, color="k",
            labels=None, label_kwargs=None,
            show_titles=False, title_fmt=".2f", title_kwargs=None,
            truths=None, truth_color="#4682b4",
-           priors=None, prior_color="#4682b4",
+           priors=None, prior_color="#ff7f0e",
            scale_hist=False, quantiles=None, verbose=False, fig=None,
            max_n_ticks=5, top_ticks=False, use_math_text=False,
            hist_kwargs=None, **hist2d_kwargs):

--- a/corner/corner.py
+++ b/corner/corner.py
@@ -252,7 +252,7 @@ def corner(xs, bins=20, range=None, weights=None, color="k",
             if gaussian_filter is None:
                 raise ImportError("Please install scipy for smoothing")
             n, b = np.histogram(x, bins=bins[i], weights=weights,
-                                range=np.sort(range[i]), density=True)
+                                range=np.sort(range[i]))
             n = gaussian_filter(n, smooth1d)
             x0 = np.array(list(zip(b[:-1], b[1:]))).flatten()
             y0 = np.array(list(zip(n, n))).flatten()


### PR DESCRIPTION
This allows someone to pass a list of prior functions to be plotted on top of the histograms.  Feel free to suggest a different default color; I just made it the same as the default `truth_color`.
