### PR TITLE
Fix bug: hist2d hangs when the range is not valid

### DIFF
--- a/corner/corner.py
+++ b/corner/corner.py
@@ -578,6 +578,9 @@ def hist2d(x, y, bins=20, range=None, weights=None, levels=None, smooth=None,
         raise ValueError("It looks like at least one of your sample columns "
                          "have no dynamic range. You could try using the "
                          "'range' argument.")
+    if H.sum() == 0:
+        raise ValueError("It looks like the provided 'range' is not valid "
+                         "or the sample is empty.")
 
     if smooth is not None:
         if gaussian_filter is None:


### PR DESCRIPTION
If no sample locates in the (wrongly) given range, `H` will be all zeros, and the function will hang forever later at the line `while np.any(m)`.
This patch will raise an error to help the users know why.