### PR TITLE
Two line title

### DIFF
--- a/corner/corner.py
+++ b/corner/corner.py
@@ -24,7 +24,7 @@ def corner(xs, bins=20, range=None, weights=None, color="k", hist_bin_factor=1,
            truths=None, truth_color="#4682b4",
            scale_hist=False, quantiles=None, verbose=False, fig=None,
            max_n_ticks=5, top_ticks=False, use_math_text=False, reverse=False,
-           hist_kwargs=None, **hist2d_kwargs):
+           hist_kwargs=None, columnwise_titles=False, **hist2d_kwargs):
     """
     Make a *sick* corner plot showing the projections of a data set in a
     multi-dimensional space. kwargs are passed to hist2d() or used for
@@ -301,7 +301,7 @@ def corner(xs, bins=20, range=None, weights=None, color="k", hist_bin_factor=1,
 
                 # Add in the column name if it's given.
                 if labels is not None:
-                    if 'columnwise' in title_kwargs.keys() and title_kwargs['columnwise']:
+                    if columnwise_titles:
                         title = "{0}\n{1}".format(labels[i], title)
                     else:
                         title = "{0} = {1}".format(labels[i], title)

--- a/corner/corner.py
+++ b/corner/corner.py
@@ -301,8 +301,11 @@ def corner(xs, bins=20, range=None, weights=None, color="k", hist_bin_factor=1,
 
                 # Add in the column name if it's given.
                 if labels is not None:
-                    title = "{0} = {1}".format(labels[i], title)
-
+                    if 'columnwise' in title_kwargs.keys() and title_kwargs['columnwise']:
+                        title = "{0}\n{1}".format(labels[i], title)
+                    else:
+                        title = "{0} = {1}".format(labels[i], title)
+            
             elif labels is not None:
                 title = "{0}".format(labels[i])
 


### PR DESCRIPTION
Changed the format of the title per column in the corner plot to place the name above the values.

I found that the `name = val_{-range}^{+ range}` usage very often over ran the axis (usually a 1D histogram) next to it.

With this `columnwise_title` flag, the name is now above the values, with no equal sign, which has yet to over run the axis next to it.