### PR TITLE
Remove unnecessary install dependencies on setuptools, wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,10 +24,7 @@ CLASSIFIERS = [
     "Programming Language :: Python :: 3",
 ]
 INSTALL_REQUIRES = [
-    "matplotlib>=2.1",
-    "setuptools>=40.6.0",
-    "setuptools_scm",
-    "wheel",
+    "matplotlib>=2.1"
 ]
 EXTRA_REQUIRE = {
     "test": [


### PR DESCRIPTION
These packages are needed for running the build system, but they are not required at run time. They should not be listed in `install_requires`.