### PR TITLE
Package need not be universal

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,5 +92,4 @@ if __name__ == "__main__":
         extras_require=EXTRA_REQUIRE,
         classifiers=CLASSIFIERS,
         zip_safe=True,
-        options={"bdist_wheel": {"universal": "1"}},
     )


### PR DESCRIPTION
Since corner.py no longer supports Python 2, there's no need for the package to be universal.