### PR TITLE
update setup.py to enforce requirement of python>=3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,6 @@ if __name__ == "__main__":
         install_requires=INSTALL_REQUIRES,
         extras_require=EXTRA_REQUIRE,
         classifiers=CLASSIFIERS,
-        python_requires='>=3.6',
+        python_requires=">=3.6",
         zip_safe=True,
     )


### PR DESCRIPTION
This updates the 'python_requires' field to actively inform to pypi that python3.6 or higher is required for this package. 

This requirement may have been in practice true beforehand but the latest released has caused issues with python2.7 installations and packages with with unpinned corner requirements. 

See also related #150 