### PR TITLE
Clarify support for using pandas column names as labels

### DIFF
--- a/src/corner/corner.py
+++ b/src/corner/corner.py
@@ -120,8 +120,14 @@ def corner(
        respectively. If `None` (default), no smoothing is applied.
 
     labels : iterable (ndim,)
-        A list of names for the dimensions. If a ``xs`` is a
-        ``pandas.DataFrame``, labels will default to column names.
+        A list of names for the dimensions.
+
+        .. deprecated:: 2.2.1
+            If a ``xs`` is a ``pandas.DataFrame`` *and* ArviZ is installed,
+            labels will default to column names.
+            This behavior will be removed in version 3;
+            either use ArviZ data structures instead or pass
+            ``labels=dataframe.columns`` manually.
 
     label_kwargs : dict
         Any extra keyword arguments to send to the `set_xlabel` and


### PR DESCRIPTION
I phrased the support for using `pandas.DataFrame.columns` for labels as a deprecated feature, but stopped short of stating that passing a `DataFrame` is unsupported---`np.atleast_1d` coerces them into suitable 2D numpy arrays, as applied by `_parse_input`.

Closes #217.