### PR TITLE
add documentation about the levels argument

### DIFF
--- a/src/corner/core.py
+++ b/src/corner/core.py
@@ -560,7 +560,10 @@ def hist2d(
         If true, suppress warnings for small datasets.
 
     levels : array_like
-        The contour levels to draw.
+        The contour levels to draw. 
+        If None, (0.5, 1, 1.5, 2)-sigma equivalent contours are drawn,
+        i.e., containing 11.8%, 39.3%, 67.5% and 86.4% of the samples.
+        See https://corner.readthedocs.io/en/latest/pages/sigmas/
 
     ax : matplotlib.Axes
         A axes instance on which to add the 2-D histogram.


### PR DESCRIPTION
I was trying to understand how to set the number of contour levels. Currently, the API doc does not list this.
There is a helpful "A note about sigmas" page.

This pull request links the former to the latter, and explains what happens when `levels=` is not provided (`None`).

I would find this helpful, but feel free to adjust.