### PR TITLE
fig keyword allows m^2 fig.axes, if m>=n sample dims.

### DIFF
--- a/src/corner/core.py
+++ b/src/corner/core.py
@@ -904,16 +904,20 @@ def _parse_input(xs):
 def _get_fig_axes(fig, K):
     if not fig.axes:
         return fig.subplots(K, K), True
-    try:
+
+    axarr = np.array(fig.axes)
+    axarr_size = axarr.size
+    if np.sqrt(axarr_size)!=int(np.sqrt(axarr_size)):
+        raise ValueError(
+            f"Provided figure has {axarr_size} axes. Must be a square number")
+    if axarr.size==K**2:
         axarr = np.array(fig.axes).reshape((K, K))
         return axarr.item() if axarr.size == 1 else axarr.squeeze(), False
-    except ValueError:
-        raise ValueError(
-            (
-                "Provided figure has {0} axes, but data has "
-                "dimensions K={1}"
-            ).format(len(fig.axes), K)
-        )
+    if axarr.size>K**2:
+        axarr_ndim = int(np.sqrt(axarr_size))
+        axarr = axarr.reshape((axarr_ndim, axarr_ndim)) # Reshape to square
+        axarr = axarr[:K, :K]
+        return axarr.squeeze(), False
 
 
 def _set_xlim(force, new_fig, ax, new_xlim):


### PR DESCRIPTION
Addresses #130, for cases where one sample is a subspace of the other.

Testing code, e.g.
```
   import corner # etc
   data = np.random.normal(size=10000).reshape(-1, 4)
   nata = np.random.normal(size=7500).reshape(-1, 3)
   fig = corner.corner(data)
   corner.corner(nata, fig=fig, color='r')
```
Notes
1. Does not check if samples make sense; in example above, `data[:, k]` is overplotted on `nata[:, k]` for `k` in `{0, 1, 2}`.
2. May need some cleaning of the `try`/`except` statements.