### PR TITLE
sigmas.ipynb: fix second plot

### DIFF
--- a/docs/pages/sigmas.ipynb
+++ b/docs/pages/sigmas.ipynb
@@ -88,7 +88,7 @@
    },
    "outputs": [],
    "source": [
-    "fig = corner.corner(x, quantiles=(q_lower, q_upper), levels=(one_sigma_2d,))\n",
+    "fig = corner.corner(x, quantiles=(q_lower, q_upper), levels=(one_sigma_1d,))\n",
     "_ = fig.suptitle(\"alternative 'one-sigma' level\")"
    ]
   },


### PR DESCRIPTION
The second corner plot was exactly the same as the first corner plot in the [documentation](https://corner.readthedocs.io/en/latest/pages/sigmas/). This PR should fix it.